### PR TITLE
Support short codes

### DIFF
--- a/crocodsl/func.py
+++ b/crocodsl/func.py
@@ -1,6 +1,8 @@
 import re
 from collections.abc import Iterable, Sequence
 
+import signed_id
+
 from .common import hash_id, utcnow
 
 
@@ -509,6 +511,29 @@ class TrimSuffix(_BinaryExpression):
         result = s.removesuffix(suffix)
 
         self._trace(log, [s, suffix], result)
+
+        return result
+
+
+class ShortCode(_BinaryExpression):
+    """Generate a signed short code with the given input and secret.
+
+    Example:
+        ShortCode($my_prop, 'shhh! secret!')
+    """
+
+    def __call__(self, *args, log=None, context=None):
+        subject, secret = self.evaluate(*args, log=log, context=context)
+
+        if not isinstance(subject, str):
+            raise TypeError(f"Expect {type(subject)} to be str")
+
+        if not isinstance(secret, str):
+            raise TypeError(f"Expect {type(secret)} to be str")
+
+        result = signed_id.generate(subject, secret)
+
+        self._trace(log, [subject, secret], result)
 
         return result
 

--- a/crocodsl/test_func.py
+++ b/crocodsl/test_func.py
@@ -251,6 +251,15 @@ class TestFunc(unittest.TestCase):
         with self.assertRaises(TypeError):
             func.TrimSuffix("abc", None)()
 
+    def test_short_code(self):
+        """Test short code generation."""
+        assert repr(func.ShortCode("a", "b")) == "ShortCode('a', 'b')"
+        assert func.ShortCode("test_input", "shh!")() == "9528c156"
+        with self.assertRaises(TypeError):
+            func.ShortCode(123, "shh!")()
+        with self.assertRaises(TypeError):
+            func.ShortCode("123", None)()
+
     def test_composition(self):
         """Make sure functions can be composed."""
         assert func.Hash(func.Concat("a", "b", "c"))() == 0.7054175881782409

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "requests~=2.32",
     "pyyaml~=6.0",
     "urllib3~=2.2",
+    "signed-id>=0.1.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -4,13 +4,14 @@ requires-python = ">=3.11, <4"
 
 [[package]]
 name = "alligater"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },
     { name = "mmh3" },
     { name = "pyyaml" },
     { name = "requests" },
+    { name = "signed-id" },
     { name = "urllib3" },
 ]
 
@@ -28,6 +29,7 @@ requires-dist = [
     { name = "mmh3", specifier = "~=4.1" },
     { name = "pyyaml", specifier = "~=6.0" },
     { name = "requests", specifier = "~=2.32" },
+    { name = "signed-id", specifier = ">=0.1.0" },
     { name = "urllib3", specifier = "~=2.2" },
 ]
 
@@ -316,6 +318,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/24/1d67c8974daa502e860b4a5b57ad6de0d7dbc0b1160ef7148189a24a40e1/responses-0.25.3.tar.gz", hash = "sha256:617b9247abd9ae28313d57a75880422d55ec63c29d33d629697590a034358dba", size = 77798, upload-time = "2024-06-14T16:32:58.41Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/24/93293d0be0db9da1ed8dfc5e6af700fdd40e8f10a928704dd179db9f03c1/responses-0.25.3-py3-none-any.whl", hash = "sha256:521efcbc82081ab8daa588e08f7e8a64ce79b91c39f6e62199b19159bea7dbcb", size = 55238, upload-time = "2024-06-14T16:32:55.758Z" },
+]
+
+[[package]]
+name = "signed-id"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/38/b88a68a72e676eec074808d4c746e79da285ed384f399c85aa1e9be38406/signed_id-0.1.0.tar.gz", hash = "sha256:4fd2d2da901fc3c3d4312957fb050a037ea85f89549f6c92d3b4c1bee44d3ca9", size = 4076, upload-time = "2025-10-09T17:51:08.207Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/a9/60e8813633834135d603c219ed826d1d89c51bd13edb3cd9b1401a8b39de/signed_id-0.1.0-py3-none-any.whl", hash = "sha256:d3dfd6fdc123b96b5e7208fa6d4dafe5132647068f870883c52cadf10bf4ea0d", size = 5160, upload-time = "2025-10-09T17:51:07.507Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a function to `crocodsl` for generating short codes via [`signed-id`](https://github.com/comppolicylab/signed-id). See that README for more information about how these codes work.

Currently only supports the passing the two required parameters, the input content and the secret. It's not currently possible to change the default code generation parameters in the language.